### PR TITLE
Fix some minor finickies while we are at it!

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
       </div>
     </div>
     <div class="flex flex-row items-center justify-center gap-[77px] relative">
-      <img class="hidden hover-scale lg:self-start lg:block" src="img/sticker2.png" />
+      <img class="hidden hover-scale xl:self-start xl:block" src="img/sticker2.png" />
       <div class="px-9 lg:px-0 lg:flex-[0_0_454px] flex flex-col gap-7 lg:gap-14 mb-16 lg:mb-[150px]">
         <h2 class="text-2xl lg:text-5xl">
           <div id="about" class="absolute -top-20"></div>
@@ -98,7 +98,7 @@
           track will have different prizes, so pick and choose your track
           depending on which prize you want to win!
         </p>
-        <div class="flex flex-col p-12 lg:flex-row gap-12">
+        <div class="flex flex-row flex-wrap justify-center pt-5 pb-12 lg:pt-1 gap-12">
           <div class="w-[298px] h-[448px] rounded-3xl bg-deep-purple p-6 hover-scale">
             <img class="w-40 mx-auto my-9" src="img/tracks/entertainment.svg" alt="A window with a video player" />
             <h3 class="mb-4 text-2xl text-center font-display">Entertainment</h3>

--- a/styles.css
+++ b/styles.css
@@ -2171,6 +2171,11 @@ h1, h2, h3, h4, h5, h6 {
   padding-right: 2.25rem;
 }
 
+.py-12 {
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+}
+
 .py-24 {
   padding-top: 6rem;
   padding-bottom: 6rem;
@@ -2196,6 +2201,14 @@ h1, h2, h3, h4, h5, h6 {
 
 .pt-32 {
   padding-top: 8rem;
+}
+
+.pb-12 {
+  padding-bottom: 3rem;
+}
+
+.pt-5 {
+  padding-top: 1.25rem;
 }
 
 .text-left {
@@ -3138,6 +3151,10 @@ canvas {
     padding-bottom: 1.25rem;
   }
 
+  .lg\:pt-1 {
+    padding-top: 0.25rem;
+  }
+
   .lg\:text-2xl {
     font-size: 1.5rem;
     line-height: 2rem;
@@ -3169,6 +3186,20 @@ canvas {
     .dark\:lg\:hover\:\[paint-order\:markers\]:hover {
       paint-order: markers;
     }
+  }
+}
+
+@media (min-width: 1280px) {
+  .xl\:relative {
+    position: relative;
+  }
+
+  .xl\:block {
+    display: block;
+  }
+
+  .xl\:self-start {
+    align-self: flex-start;
   }
 }
 


### PR DESCRIPTION
- On the iPad horizontal, before 2 stickers would appear in the About section, but both of them are clipped because the screen is not enough. Why not display only 1 instead, and for xl+ screens, we display both? : )
- Tracks section was annoying before. Either they were all hori- zontal or all vertical. Looked especially bad on iPad portrait, since there was much horizontal space but it was displaying in portrait. Fixed this with flex-wrap. : )